### PR TITLE
Adds initial .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Intellij
+/.idea/*
+
+# VS Code
+/.vscode/*
+
+# Mac
+.DS_Store
+.AppleDouble
+.LSOverride


### PR DESCRIPTION
Add a `.gitignore` file to the repository's main folder.

- Prevents unnecessary files generated by IDEs (IntelliJ, VS Code) and the operating system (macOS) from being tracked by Git.