### PR TITLE
feat: implement local login with automatic API user ID headers

### DIFF
--- a/front/src/api/axiosInstance.jsx
+++ b/front/src/api/axiosInstance.jsx
@@ -1,17 +1,29 @@
 import axios from 'axios';
 
+let currentUser = null;
+
+// authContext에서 API 요청에 사용할 사용자 정보를 설정하는 함수
+export const setUserForApiRequests = (user) => {
+  currentUser = user;
+};
+
 const api = axios.create({
   baseURL: '/',
   timeout: 5000,
 });
 
-// 요청 인터셉터 (예: 토큰 자동 주입)
+// 요청 인터셉터 (토큰 자동 주입, 사용자 ID 자동 추가)
 api.interceptors.request.use((config) => {
   const token = localStorage.getItem('auth_token');
 
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
+
+  if (currentUser?.id) {
+    config.headers['X-User-ID'] = currentUser.id;
+  }
+
   return config;
 });
 

--- a/front/src/api/axiosInstance.jsx
+++ b/front/src/api/axiosInstance.jsx
@@ -7,7 +7,8 @@ const api = axios.create({
 
 // 요청 인터셉터 (예: 토큰 자동 주입)
 api.interceptors.request.use((config) => {
-  const token = localStorage.getItem('access_token');
+  const token = localStorage.getItem('auth_token');
+
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }

--- a/front/src/components/LocalLoginButton.jsx
+++ b/front/src/components/LocalLoginButton.jsx
@@ -1,0 +1,32 @@
+import { useState } from 'react';
+import { useAuth } from '../utils/authContext';
+import styles from './LocalLoginButton.module.css';
+
+const LocalLoginButton = () => {
+  const [userId, setUserId] = useState('');
+  const { login } = useAuth();
+
+  const handleLocalLogin = () => {
+    if (userId.trim()) {
+      login(userId, 'local_user', `${userId}@local.com`);
+    }
+  };
+
+  return (
+    <div className={styles.container}>
+      <input
+        type='text'
+        placeholder='Enter User ID'
+        value={userId}
+        onChange={(e) => setUserId(e.target.value)}
+        className={styles.input}
+        onKeyDown={(e) => e.key === 'Enter' && handleLocalLogin()}
+      />
+      <button onClick={handleLocalLogin} className={styles.button}>
+        Login
+      </button>
+    </div>
+  );
+};
+
+export default LocalLoginButton;

--- a/front/src/components/LocalLoginButton.module.css
+++ b/front/src/components/LocalLoginButton.module.css
@@ -1,0 +1,42 @@
+.container {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 15px;
+}
+
+.input {
+  padding: 12px 16px;
+  border: 2px solid #ddd;
+  border-radius: 8px;
+  font-size: 16px;
+  width: 300px;
+  outline: none;
+  transition: border-color 0.2s;
+}
+
+.input:focus {
+  border-color: #4285f4;
+}
+
+.button {
+  padding: 12px 24px;
+  background-color: #4285f4;
+  color: white;
+  border: none;
+  border-radius: 8px;
+  font-size: 16px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  width: 300px;
+}
+
+.button:hover {
+  background-color: #3367d6;
+}
+
+.button:disabled {
+  background-color: #ccc;
+  cursor: not-allowed;
+}

--- a/front/src/pages/LoginPage.jsx
+++ b/front/src/pages/LoginPage.jsx
@@ -1,10 +1,13 @@
-import GoogleLoginButton from '../components/GoogleLoginButton';
+import LocalLoginButton from '../components/LocalLoginButton';
 import styles from './LoginPage.module.css';
 
 const LoginPage = () => {
   return (
     <div className={styles.container}>
-      <div className={styles.loginBox}>{<GoogleLoginButton />}</div>
+      <div className={styles.loginBox}>
+        <LocalLoginButton />
+        {/* <GoogleLoginButton /> */}
+      </div>
     </div>
   );
 };

--- a/front/src/utils/authContext.jsx
+++ b/front/src/utils/authContext.jsx
@@ -15,7 +15,7 @@ export const AuthProvider = ({ children, onLoginSuccess, onLogoutSuccess, initia
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(initialLoading);
 
-  const tokenKey = 'google_token';
+  const tokenKey = 'auth_token';
   const userDataKey = 'user_data';
 
   useEffect(() => {
@@ -39,7 +39,8 @@ export const AuthProvider = ({ children, onLoginSuccess, onLogoutSuccess, initia
     setLoading(false);
   }, [tokenKey, userDataKey, onLoginSuccess]);
 
-  const login = (userData, token) => {
+  const login = (id, name, email, token = 'local_token') => {
+    const userData = { id, name, email };
     setUser(userData);
     localStorage.setItem(tokenKey, token);
     localStorage.setItem(userDataKey, JSON.stringify(userData));
@@ -50,18 +51,18 @@ export const AuthProvider = ({ children, onLoginSuccess, onLogoutSuccess, initia
   };
 
   const logout = () => {
-    const currentUser = user;
+    const currentUserData = user;
     setUser(null);
     localStorage.removeItem(tokenKey);
     localStorage.removeItem(userDataKey);
 
-    // Google 로그아웃
-    if (window.google?.accounts?.id) {
+    // Google 로그아웃 (구글 로그인을 사용한 경우에만)
+    if (window.google?.accounts?.id && localStorage.getItem(tokenKey) !== 'local_token') {
       window.google.accounts.id.disableAutoSelect();
     }
 
     if (onLogoutSuccess) {
-      onLogoutSuccess(currentUser);
+      onLogoutSuccess(currentUserData);
     }
   };
 

--- a/front/src/utils/authContext.jsx
+++ b/front/src/utils/authContext.jsx
@@ -1,5 +1,6 @@
 import { createContext, useContext, useState, useEffect } from 'react';
 import PropTypes from 'prop-types';
+import { setUserForApiRequests } from '../api/axiosInstance';
 
 const AuthContext = createContext();
 
@@ -27,6 +28,7 @@ export const AuthProvider = ({ children, onLoginSuccess, onLogoutSuccess, initia
       try {
         const parsedUserData = JSON.parse(userData);
         setUser(parsedUserData);
+        setUserForApiRequests(parsedUserData);
         if (onLoginSuccess) {
           onLoginSuccess(parsedUserData, token);
         }
@@ -42,6 +44,7 @@ export const AuthProvider = ({ children, onLoginSuccess, onLogoutSuccess, initia
   const login = (id, name, email, token = 'local_token') => {
     const userData = { id, name, email };
     setUser(userData);
+    setUserForApiRequests(userData);
     localStorage.setItem(tokenKey, token);
     localStorage.setItem(userDataKey, JSON.stringify(userData));
 
@@ -53,6 +56,7 @@ export const AuthProvider = ({ children, onLoginSuccess, onLogoutSuccess, initia
   const logout = () => {
     const currentUserData = user;
     setUser(null);
+    setUserForApiRequests(null);
     localStorage.removeItem(tokenKey);
     localStorage.removeItem(userDataKey);
 


### PR DESCRIPTION
 Description:
  ## Summary
  - Implement local login functionality allowing users to log in with custom user IDs
  - Add automatic user ID header injection to all API requests
  - Maintain existing Google login functionality (commented out but preserved)

  ## Changes
  ### Local Login Implementation
  - Add `LocalLoginButton` component with user ID input field
  - Create corresponding CSS module for styling
  - Update `LoginPage` to use local login (Google login commented out)
  - Modify `authContext` to support both Google and local authentication

  ### API Integration
  - Update `axiosInstance` to automatically include `X-User-ID` header in all requests
  - Implement user state management for API requests