### PR TITLE
fix: use actual user ID instead of hardcoded name in local login

### DIFF
--- a/front/src/components/LocalLoginButton.jsx
+++ b/front/src/components/LocalLoginButton.jsx
@@ -8,7 +8,7 @@ const LocalLoginButton = () => {
 
   const handleLocalLogin = () => {
     if (userId.trim()) {
-      login(userId, 'local_user', `${userId}@local.com`);
+      login(userId, userId, `${userId}@local.com`);
     }
   };
 


### PR DESCRIPTION
 Description:
  ## Summary
  Fix local login functionality to display the actual entered user ID instead of hardcoded 'local_user' string.

  ## Problem
  When users logged in using the local login feature, their display name was always shown as "local_user" regardless of what they entered in the user ID field.

  ## Solution
  - Replace hardcoded `'local_user'` with the actual `userId` value in the login function
  - Now users will see their actual entered user ID in the greeting message

  ## Changes
  - Update `LocalLoginButton.jsx`: Change `login(userId, 'local_user', ...)` to `login(userId, userId, ...)`