### PR TITLE
feat: add custom video timeline preview and controls

### DIFF
--- a/front/src/components/VideoPlayer.jsx
+++ b/front/src/components/VideoPlayer.jsx
@@ -1,6 +1,12 @@
+import { useState, useEffect, useMemo, useRef } from 'react';
 import PropTypes from 'prop-types';
 import { Play, Pause } from 'lucide-react';
+import { formatVideoTime } from '../utils/chatRoomManager';
+import { generateVideoThumbnails, getClosestThumbnail } from '../utils/videoThumbnails';
 import styles from './VideoPlayer.module.css';
+
+const DEFAULT_ASPECT_RATIO = '16 / 9';
+const PREVIEW_IMAGE_WIDTH = 160;
 
 const VideoPlayer = ({
   videoFile,
@@ -16,20 +22,268 @@ const VideoPlayer = ({
   // onFileUpload,
   // onUploadClick,
 }) => {
+  const [duration, setDuration] = useState(0);
+  const [currentTime, setCurrentTime] = useState(0);
+  const [scrubTime, setScrubTime] = useState(null);
+  const [isScrubbing, setIsScrubbing] = useState(false);
+  const [wasPlayingBeforeScrub, setWasPlayingBeforeScrub] = useState(false);
+  const [hoverTime, setHoverTime] = useState(null);
+  const [hoverPercent, setHoverPercent] = useState(null);
+  const [thumbnails, setThumbnails] = useState([]);
+  const [thumbnailsLoading, setThumbnailsLoading] = useState(false);
+  const [thumbnailError, setThumbnailError] = useState(false);
+  const [containerAspectRatio, setContainerAspectRatio] = useState(DEFAULT_ASPECT_RATIO);
+  const progressRef = useRef(null);
+
+  useEffect(() => {
+    setDuration(0);
+    setCurrentTime(0);
+    setScrubTime(null);
+    setHoverTime(null);
+    setHoverPercent(null);
+    setContainerAspectRatio(DEFAULT_ASPECT_RATIO);
+
+    let isCancelled = false;
+
+    if (!videoUrl) {
+      setThumbnails([]);
+      setThumbnailsLoading(false);
+      setThumbnailError(false);
+      setContainerAspectRatio(DEFAULT_ASPECT_RATIO);
+      return () => {
+        isCancelled = true;
+      };
+    }
+
+    setThumbnails([]);
+    setThumbnailsLoading(true);
+    setThumbnailError(false);
+
+    generateVideoThumbnails(videoUrl, { interval: 1 })
+      .then((result) => {
+        if (!isCancelled) {
+          setThumbnails(result);
+        }
+      })
+      .catch(() => {
+        if (!isCancelled) {
+          setThumbnailError(true);
+        }
+      })
+      .finally(() => {
+        if (!isCancelled) {
+          setThumbnailsLoading(false);
+        }
+      });
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [videoUrl]);
+
+  const activeTime = useMemo(() => {
+    if (isScrubbing && scrubTime !== null) {
+      return scrubTime;
+    }
+    return currentTime;
+  }, [isScrubbing, scrubTime, currentTime]);
+
+  const clampedDuration = duration > 0 ? duration : 0;
+  const clampedActiveTime = clampedDuration ? Math.min(Math.max(activeTime, 0), clampedDuration) : 0;
+  const playbackPercent = clampedDuration ? (clampedActiveTime / clampedDuration) * 100 : 0;
+  const safePlaybackPercent = Math.min(Math.max(playbackPercent, 0), 100);
+
+  const previewThumbnail = useMemo(() => {
+    if (hoverTime === null) {
+      return null;
+    }
+    return getClosestThumbnail(thumbnails, hoverTime);
+  }, [hoverTime, thumbnails]);
+
+  const handleLoadedMetadata = (event) => {
+    const videoElement = event.target;
+    setDuration(videoElement.duration || 0);
+    setCurrentTime(videoElement.currentTime || 0);
+    if (videoElement.videoWidth && videoElement.videoHeight) {
+      setContainerAspectRatio(`${videoElement.videoWidth} / ${videoElement.videoHeight}`);
+    } else {
+      setContainerAspectRatio(DEFAULT_ASPECT_RATIO);
+    }
+  };
+
+  const handleTimeUpdate = (event) => {
+    if (isScrubbing) {
+      return;
+    }
+    setCurrentTime(event.target.currentTime);
+  };
+
+  const computeRelativePosition = (event) => {
+    if (!progressRef.current) {
+      return null;
+    }
+    const rect = progressRef.current.getBoundingClientRect();
+    const ratio = rect.width ? (event.clientX - rect.left) / rect.width : 0;
+    const clampedRatio = Math.min(Math.max(ratio, 0), 1);
+    return {
+      time: clampedRatio * clampedDuration,
+      percent: clampedRatio * 100,
+    };
+  };
+
+  const toDisplayPercent = (percent) => {
+    if (percent === null || percent === undefined) {
+      return null;
+    }
+    if (!progressRef.current) {
+      return percent;
+    }
+    const width = progressRef.current.clientWidth || 0;
+    if (!width) {
+      return percent;
+    }
+    const halfPreviewPercent = Math.min(((PREVIEW_IMAGE_WIDTH / 2) / width) * 100, 50);
+    return Math.min(Math.max(percent, halfPreviewPercent), 100 - halfPreviewPercent);
+  };
+
+  const clearHoverState = () => {
+    setHoverTime(null);
+    setHoverPercent(null);
+  };
+
+  const releasePointerCapture = (event) => {
+    if (progressRef.current?.hasPointerCapture?.(event.pointerId)) {
+      progressRef.current.releasePointerCapture(event.pointerId);
+    }
+  };
+
+  const handlePointerDown = (event) => {
+    if (!videoRef.current || !clampedDuration) {
+      return;
+    }
+    event.preventDefault();
+    progressRef.current?.setPointerCapture?.(event.pointerId);
+    const position = computeRelativePosition(event);
+    if (!position) {
+      return;
+    }
+
+    onVideoSeeking();
+    setIsScrubbing(true);
+    setScrubTime(position.time);
+    setHoverTime(position.time);
+    setHoverPercent(toDisplayPercent(position.percent));
+
+    const wasPlaying = !videoRef.current.paused;
+    setWasPlayingBeforeScrub(wasPlaying);
+
+    if (wasPlaying) {
+      videoRef.current.pause();
+    }
+
+    videoRef.current.currentTime = position.time;
+  };
+
+  const handlePointerMove = (event) => {
+    if (!clampedDuration) {
+      return;
+    }
+    const position = computeRelativePosition(event);
+    if (!position) {
+      return;
+    }
+
+    setHoverTime(position.time);
+    setHoverPercent(toDisplayPercent(position.percent));
+
+    if (isScrubbing && videoRef.current) {
+      setScrubTime(position.time);
+      videoRef.current.currentTime = position.time;
+    }
+  };
+
+  const finishScrubbing = async (event) => {
+    if (!isScrubbing || !videoRef.current) {
+      return;
+    }
+    const position = computeRelativePosition(event);
+    const finalTime = position ? position.time : clampedActiveTime;
+
+    setIsScrubbing(false);
+    setScrubTime(null);
+    setCurrentTime(finalTime);
+    setHoverTime(finalTime);
+    const finalPercent = position ? position.percent : clampedDuration ? (finalTime / clampedDuration) * 100 : null;
+    setHoverPercent(toDisplayPercent(finalPercent));
+
+    videoRef.current.currentTime = finalTime;
+    onVideoSeeked();
+
+    if (wasPlayingBeforeScrub) {
+      try {
+        await videoRef.current.play();
+      } catch (error) {
+        // Autoplay restrictions may block programmatic play; ignore.
+      }
+    }
+
+    setWasPlayingBeforeScrub(false);
+  };
+
+  const handlePointerUp = (event) => {
+    releasePointerCapture(event);
+    finishScrubbing(event);
+  };
+
+  const handlePointerLeave = (event) => {
+    if (!isScrubbing) {
+      clearHoverState();
+    } else {
+      // Keep preview aligned with exit position.
+      handlePointerMove(event);
+    }
+  };
+
+  const handlePointerCancel = (event) => {
+    releasePointerCapture(event);
+    if (isScrubbing) {
+      finishScrubbing(event);
+    } else {
+      clearHoverState();
+    }
+  };
+
+  const handleVideoSurfaceClick = (event) => {
+    if (!videoRef.current || !videoUrl) {
+      return;
+    }
+    if (event.detail > 1 || isScrubbing) {
+      return;
+    }
+    onVideoToggle();
+  };
+
+  const displayDuration = formatVideoTime(clampedDuration || 0);
+  const displayTime = formatVideoTime(clampedActiveTime || 0);
+  const hoverLabel = hoverTime !== null ? formatVideoTime(hoverTime) : '';
+  const previewLeft = hoverPercent !== null ? Math.min(Math.max(hoverPercent, 0), 100) : 0;
+
   return (
     <>
-      <div className={styles.container}>
+      <div className={styles.container} style={{ aspectRatio: containerAspectRatio }}>
         {videoUrl ? (
           <video
             key={videoUrl}
             ref={videoRef}
             src={videoUrl}
             className={styles.player}
+            onLoadedMetadata={handleLoadedMetadata}
+            onTimeUpdate={handleTimeUpdate}
             onPlay={onVideoPlay}
             onPause={onVideoPause}
             onSeeking={onVideoSeeking}
             onSeeked={onVideoSeeked}
-            controls
+            onClick={handleVideoSurfaceClick}
           >
             비디오를 지원하지 않는 브라우저입니다.
           </video>
@@ -38,6 +292,47 @@ const VideoPlayer = ({
             <div>
               <div className={styles.icon}>📹</div>
               <p className={styles.placeholderText}>비디오를 업로드해주세요</p>
+            </div>
+          </div>
+        )}
+        {videoUrl && (
+          <div className={styles.controlsContainer}>
+            <div
+              className={styles.timeline}
+              ref={progressRef}
+              onPointerDown={handlePointerDown}
+              onPointerMove={handlePointerMove}
+              onPointerLeave={handlePointerLeave}
+              onPointerUp={handlePointerUp}
+              onPointerCancel={handlePointerCancel}
+            >
+              <div className={styles.timelineTrack} />
+              <div className={styles.timelineProgress} style={{ width: `${safePlaybackPercent}%` }} />
+              {hoverTime !== null && (
+                <div
+                  className={styles.timelinePreview}
+                  style={{ left: `${previewLeft}%` }}
+                >
+                  {previewThumbnail?.image && !thumbnailError ? (
+                    <img src={previewThumbnail.image} alt={`Preview at ${hoverLabel}`} />
+                  ) : (
+                    <span className={styles.timelinePreviewFallback}>{hoverLabel}</span>
+                  )}
+                  <span className={styles.timelinePreviewTime}>{hoverLabel}</span>
+                </div>
+              )}
+            </div>
+            <div className={styles.controlsRow}>
+              <button type='button' onClick={onVideoToggle} className={styles.controlButton}>
+                {isPlaying ? <Pause size={20} /> : <Play size={20} />}
+              </button>
+              <span className={styles.timeInfo}>
+                {displayTime} / {displayDuration}
+              </span>
+              {thumbnailsLoading && <span className={styles.loadingHint}>썸네일 생성 중...</span>}
+              {thumbnailError && !thumbnailsLoading && (
+                <span className={styles.loadingHint}>썸네일을 불러오지 못했습니다</span>
+              )}
             </div>
           </div>
         )}

--- a/front/src/components/VideoPlayer.module.css
+++ b/front/src/components/VideoPlayer.module.css
@@ -10,16 +10,145 @@
   border-radius: 8px;
   overflow: hidden;
   margin-bottom: 16px;
+  width: 100%;
+  aspect-ratio: 16 / 9;
+  min-height: 220px;
 }
 
 .player {
   width: 100%;
-  height: 384px;
+  height: 100%;
+  display: block;
+  position: absolute;
+  inset: 0;
+  object-fit: contain;
+  background-color: black;
+}
+
+.controlsContainer {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 12px 16px 16px;
+  background: linear-gradient(180deg, rgba(0, 0, 0, 0) 0%, rgba(17, 24, 39, 0.65) 55%, rgba(17, 24, 39, 0.85) 100%);
+  color: #f9fafb;
+  pointer-events: none;
+}
+
+.timeline {
+  position: relative;
+  width: 100%;
+  height: 18px;
+  cursor: pointer;
+  user-select: none;
+  touch-action: none;
+  pointer-events: auto;
+}
+
+.timelineTrack {
+  position: absolute;
+  left: 0;
+  top: 50%;
+  width: 100%;
+  height: 4px;
+  background: rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
+  transform: translateY(-50%);
+}
+
+.timelineProgress {
+  position: absolute;
+  left: 0;
+  top: 50%;
+  height: 4px;
+  background: #3b82f6;
+  border-radius: 999px;
+  transform: translateY(-50%);
+}
+
+.timelinePreview {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  transform: translateX(-50%);
+  pointer-events: none;
+  z-index: 2;
+}
+
+.timelinePreview img {
+  width: 160px;
+  height: 90px;
   object-fit: cover;
+  border-radius: 8px;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.4);
+  background: #111827;
+}
+
+.timelinePreviewFallback {
+  display: inline-block;
+  padding: 6px 10px;
+  background: rgba(15, 23, 42, 0.85);
+  border-radius: 6px;
+  font-size: 12px;
+  color: #f9fafb;
+  text-align: center;
+  white-space: nowrap;
+}
+
+.timelinePreviewTime {
+  margin-top: 4px;
+  padding: 4px 8px;
+  background: rgba(15, 23, 42, 0.9);
+  border-radius: 999px;
+  font-size: 12px;
+  color: #f9fafb;
+  white-space: nowrap;
+}
+
+.controlsRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-top: 12px;
+  flex-wrap: wrap;
+  pointer-events: auto;
+}
+
+.controlButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px;
+  height: 40px;
+  border-radius: 999px;
+  border: none;
+  background: rgba(59, 130, 246, 0.9);
+  color: white;
+  cursor: pointer;
+  transition: background 0.2s ease;
+}
+
+.controlButton:hover {
+  background: rgba(37, 99, 235, 0.95);
+}
+
+.timeInfo {
+  font-size: 14px;
+  color: #e5e7eb;
+  min-width: 120px;
+}
+
+.loadingHint {
+  font-size: 12px;
+  color: #d1d5db;
 }
 
 .placeholder {
-  height: 384px;
+  position: absolute;
+  inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/front/src/utils/videoThumbnails.js
+++ b/front/src/utils/videoThumbnails.js
@@ -1,0 +1,141 @@
+const DEFAULT_INTERVAL_SECONDS = 5;
+const DEFAULT_MAX_THUMBNAILS = 200;
+const TARGET_THUMBNAIL_WIDTH = 160;
+
+/**
+ * Generate preview thumbnails for a video URL.
+ * Captures frames at a fixed interval and returns [{ time, image }] entries.
+ */
+export const generateVideoThumbnails = (videoUrl, options = {}) => {
+  const { interval = DEFAULT_INTERVAL_SECONDS, maxThumbnails = DEFAULT_MAX_THUMBNAILS } = options;
+
+  if (!videoUrl) {
+    return Promise.resolve([]);
+  }
+
+  return new Promise((resolve, reject) => {
+    const video = document.createElement('video');
+    video.preload = 'auto';
+    video.crossOrigin = 'anonymous';
+    video.src = videoUrl;
+
+    const canvas = document.createElement('canvas');
+    const context = canvas.getContext('2d', { willReadFrequently: true });
+
+    const thumbnails = [];
+    let captureTimes = [];
+    let currentIndex = 0;
+
+    const cleanup = () => {
+      video.pause();
+      video.removeEventListener('loadedmetadata', handleLoadedMetadata);
+      video.removeEventListener('seeked', handleSeeked);
+      video.removeEventListener('error', handleError);
+    };
+
+    const handleError = () => {
+      cleanup();
+      reject(new Error('Failed to load video for thumbnail generation'));
+    };
+
+    const captureFrame = () => {
+      if (!video.videoWidth || !video.videoHeight) {
+        return;
+      }
+
+      const aspectRatio = video.videoWidth / video.videoHeight;
+      const width = Math.min(TARGET_THUMBNAIL_WIDTH, video.videoWidth);
+      const height = width / aspectRatio;
+
+      canvas.width = width;
+      canvas.height = height;
+      context.drawImage(video, 0, 0, width, height);
+      try {
+        thumbnails.push({ time: video.currentTime, image: canvas.toDataURL('image/jpeg', 0.7) });
+      } catch (error) {
+        cleanup();
+        resolve([]);
+        return false;
+      }
+      return true;
+    };
+
+    const seekToNextCapture = () => {
+      currentIndex += 1;
+
+      if (currentIndex >= captureTimes.length) {
+        cleanup();
+        resolve(thumbnails);
+        return;
+      }
+
+      const targetTime = captureTimes[currentIndex];
+
+      if (Math.abs(video.currentTime - targetTime) < 0.001) {
+        // Already at target (can happen when duration === targetTime)
+        captureFrame();
+        seekToNextCapture();
+      } else {
+        video.currentTime = targetTime;
+      }
+    };
+
+    const handleSeeked = () => {
+      const captured = captureFrame();
+      if (captured) {
+        seekToNextCapture();
+      }
+    };
+
+    const handleLoadedMetadata = () => {
+      const duration = Number.isFinite(video.duration) ? video.duration : 0;
+
+      if (!duration) {
+        cleanup();
+        resolve([]);
+        return;
+      }
+
+      const safeInterval = interval > 0 ? interval : DEFAULT_INTERVAL_SECONDS;
+      const times = [];
+      let time = 0;
+
+      while (time < duration && times.length < maxThumbnails) {
+        times.push(time);
+        time += safeInterval;
+      }
+
+      if (times[times.length - 1] !== duration && times.length < maxThumbnails) {
+        times.push(duration);
+      }
+
+      captureTimes = times;
+      currentIndex = 0;
+
+      video.currentTime = captureTimes[currentIndex];
+    };
+
+    video.addEventListener('loadedmetadata', handleLoadedMetadata);
+    video.addEventListener('seeked', handleSeeked);
+    video.addEventListener('error', handleError, { once: true });
+  });
+};
+
+export const getClosestThumbnail = (thumbnails, timeInSeconds) => {
+  if (!thumbnails?.length) {
+    return null;
+  }
+
+  let closest = thumbnails[0];
+  let minDiff = Math.abs(closest.time - timeInSeconds);
+
+  for (let i = 1; i < thumbnails.length; i += 1) {
+    const diff = Math.abs(thumbnails[i].time - timeInSeconds);
+    if (diff < minDiff) {
+      closest = thumbnails[i];
+      minDiff = diff;
+    }
+  }
+
+  return closest;
+};


### PR DESCRIPTION
- Added state management for playback progress, thumbnail generation, and aspect-ratio handling so the player preserves the source dimensions and reacts to single-click play/pause (front/src/components/VideoPlayer.jsx:35).
- Introduced a thumbnail utility that captures frames at one-second intervals for use in the timeline hover preview (front/src/utils/videoThumbnails.js:1).
- Updated styling to switch to custom controls, clamp the preview just above the rail, and ensure the video canvas letterboxes instead of cropping (front/src/components/VideoPlayer.module.css:7).
